### PR TITLE
Fix hero badge spacing

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -232,7 +232,7 @@ const Hero: React.FC<HeroProps> = ({ setCurrentView }) => {
         ))}
       </div>
 
-      <div className="relative z-10 max-w-7xl mx-auto px-6 text-center">
+      <div className="relative z-10 max-w-7xl mx-auto px-6 text-center mt-32">
         <motion.div
           initial={{ y: 50, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}


### PR DESCRIPTION
## Summary
- space the hero badge so it sits below the navbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686477d7be9c832faf1c8ae2c91119ff