### PR TITLE
Overlay pixel effect on poster

### DIFF
--- a/src/components/PixelCard.css
+++ b/src/components/PixelCard.css
@@ -2,6 +2,10 @@
   width: 100%;
   height: 100%;
   display: block;
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
 }
 
 .pixel-card {


### PR DESCRIPTION
## Summary
- overlay canvas on top of pixel card content so the pixel effect appears over posters

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npx vitest` *(fails: prompts to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_686481a2172c832f9c4b00552b06268a