### PR TITLE
Fix project modal from search and allow full scroll

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,6 +5,8 @@ import { useTheme } from './ThemeProvider';
 import { useAuth } from './auth/AuthProvider';
 import SearchBar from './SearchBar';
 import NotificationDropdown from './NotificationDropdown';
+import ProjectDetailModal from './ProjectDetailModal';
+import { Project } from '../types';
 
 interface NavigationProps {
   currentView: 'home' | 'dashboard' | 'projects' | 'community' | 'merch' | 'profile' | 'admin' | 'portfolio' | 'compare' | 'news' | 'notifications' | 'search';
@@ -17,6 +19,8 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
   const [isScrolled, setIsScrolled] = useState(false);
   const [showMoreMenu, setShowMoreMenu] = useState(false);
   const [showUserMenu, setShowUserMenu] = useState(false);
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+  const [isProjectModalOpen, setIsProjectModalOpen] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const { user, isAuthenticated, logout } = useAuth();
 
@@ -69,6 +73,11 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
   const handleLogout = () => {
     logout();
     setShowUserMenu(false);
+  };
+
+  const handleProjectSelect = (project: Project) => {
+    setSelectedProject(project);
+    setIsProjectModalOpen(true);
   };
 
   return (
@@ -212,11 +221,8 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
                 <div className="flex items-center gap-4">
                   {/* Search Button */}
                   <div className="relative">
-                    <SearchBar 
-                      onSelectProject={(project) => {
-                        // Handle project selection
-                        console.log('Selected project:', project);
-                      }}
+                    <SearchBar
+                      onSelectProject={handleProjectSelect}
                       onViewAllResults={() => {
                         setCurrentView('search');
                       }}
@@ -682,6 +688,14 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
           </motion.div>
         )}
       </AnimatePresence>
+      <ProjectDetailModal
+        project={selectedProject}
+        isOpen={isProjectModalOpen}
+        onClose={() => {
+          setIsProjectModalOpen(false);
+          setSelectedProject(null);
+        }}
+      />
     </>
   );
 };

--- a/src/components/ProjectDetailModal.tsx
+++ b/src/components/ProjectDetailModal.tsx
@@ -278,7 +278,7 @@ TITLE CARD: "NEON NIGHTS"`,
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.9, y: 50 }}
             transition={{ duration: 0.3 }}
-            className={`relative w-full max-w-7xl max-h-[90vh] mx-auto mt-[5vh] rounded-2xl border overflow-hidden ${
+            className={`relative w-full max-w-7xl max-h-[90vh] mx-auto mt-[5vh] rounded-2xl border overflow-y-auto ${
               theme === 'light'
                 ? 'light-glass-header'
                 : 'bg-gradient-to-br from-gray-900 to-black border-white/20'
@@ -349,7 +349,7 @@ TITLE CARD: "NEON NIGHTS"`,
             </div>
 
             {/* Content */}
-            <div className="flex h-[calc(90vh-16rem)]">
+            <div className="flex">
               {/* Scrollable Sidebar Navigation */}
               <div className={`w-80 border-r flex flex-col ${
                 theme === 'light' 


### PR DESCRIPTION
## Summary
- open `ProjectDetailModal` when selecting a project from `SearchBar`
- add project modal state to `Navigation`
- let whole `ProjectDetailModal` scroll instead of fixing header

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865df6703a8832fa697c9979974f472