### PR TITLE
Fix trending row card alignment

### DIFF
--- a/src/components/ProjectCatalog.tsx
+++ b/src/components/ProjectCatalog.tsx
@@ -699,12 +699,11 @@ const ProjectCatalog: React.FC = () => {
         ) : (
           <div className="space-y-12">
             {/* Netflix-style Sections with Clickable Headers */}
-            <ProjectRow 
-              title="🔥 Trending Now" 
-              projects={trendingProjects} 
+            <ProjectRow
+              title="🔥 Trending Now"
+              projects={trendingProjects}
               onProjectClick={handleProjectClick}
               onHeaderClick={() => handleSectionClick('trending')}
-              featured
             />
             
             {endingSoon.length > 0 && (


### PR DESCRIPTION
## Summary
- remove `featured` prop from trending project row so its first card matches others

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865e7536f1c832f81ea7ec9d657338a