### PR TITLE
Add invest navigation and tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ function AppContent() {
   const renderCurrentView = () => {
     switch (currentView) {
       case 'projects':
-        return <ProjectCatalog />;
+        return <ProjectCatalog onTrackInvestment={() => handleViewChange('dashboard')} />;
       case 'dashboard':
         // Dashboard is now accessible without login
         return <Dashboard />;
@@ -74,7 +74,7 @@ function AppContent() {
       case 'portfolio':
         return isAuthenticated ? <PortfolioAnalytics /> : null;
       case 'compare':
-        return <ProjectComparison />;
+        return <ProjectComparison onTrackInvestment={() => handleViewChange('dashboard')} setCurrentView={handleViewChange} />;
       case 'news':
         return <NewsAndUpdates />;
       case 'notifications':
@@ -87,7 +87,10 @@ function AppContent() {
             <Hero setCurrentView={handleViewChange} />
             <ProblemSolution />
             <HowItWorks />
-            <LiveProjects onViewAll={() => handleViewChange('projects')} />
+            <LiveProjects
+              onViewAll={() => handleViewChange('projects')}
+              onTrackInvestment={() => handleViewChange('dashboard')}
+            />
             <WhyThisMatters onJoin={() => handleAuthRequired('register')} />
             <TechTrust />
             <Rewards />

--- a/src/components/LiveProjects.tsx
+++ b/src/components/LiveProjects.tsx
@@ -8,26 +8,31 @@ import { Project } from '../types';
 import { useTheme } from './ThemeProvider';
 import Typewriter from './Typewriter';
 
+
 interface LiveProjectsProps {
   onViewAll?: () => void;
+  onTrackInvestment?: () => void;
 }
 
-const LiveProjects: React.FC<LiveProjectsProps> = ({ onViewAll }) => {
+const LiveProjects: React.FC<LiveProjectsProps> = ({ onViewAll, onTrackInvestment }) => {
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [initialTab, setInitialTab] = useState<'overview' | 'invest'>('overview');
   const { theme } = useTheme();
 
   const sorted = [...extendedProjects].sort((a, b) => b.raisedAmount - a.raisedAmount);
   const trendingProjects = sorted.slice(0, Math.min(Math.max(3, sorted.length), 6));
 
-  const handleProjectClick = (project: Project) => {
+  const handleProjectClick = (project: Project, tab: 'overview' | 'invest' = 'overview') => {
     setSelectedProject(project);
+    setInitialTab(tab);
     setIsModalOpen(true);
   };
 
   const closeModal = () => {
     setIsModalOpen(false);
     setSelectedProject(null);
+    setInitialTab('overview');
   };
 
   return (
@@ -191,8 +196,8 @@ const LiveProjects: React.FC<LiveProjectsProps> = ({ onViewAll }) => {
                 </div>
 
                 {/* CTA Button */}
-                <button 
-                  onClick={() => handleProjectClick(project)}
+                <button
+                  onClick={() => handleProjectClick(project, 'invest')}
                   className={`w-full py-3 px-6 rounded-xl font-semibold transition-all duration-300 group ${
                     project.type === 'film'
                       ? 'bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white'
@@ -201,6 +206,20 @@ const LiveProjects: React.FC<LiveProjectsProps> = ({ onViewAll }) => {
                 >
                   <span className="flex items-center justify-center gap-2">
                     Support This {project.type === 'film' ? 'Film' : 'Album'}
+                    <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
+                  </span>
+                </button>
+
+                <button
+                  onClick={() => handleProjectClick(project, 'invest')}
+                  className={`mt-2 w-full py-3 px-6 rounded-xl font-semibold transition-all duration-300 group ${
+                    project.type === 'film'
+                      ? 'bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white'
+                      : 'bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-500 hover:to-cyan-500 text-white'
+                  } hover:scale-105 hover:shadow-lg`}
+                >
+                  <span className="flex items-center justify-center gap-2">
+                    Invest Now
                     <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
                   </span>
                 </button>
@@ -280,10 +299,12 @@ const LiveProjects: React.FC<LiveProjectsProps> = ({ onViewAll }) => {
       </div>
 
       {/* Project Detail Modal */}
-      <ProjectDetailModal 
+      <ProjectDetailModal
         project={selectedProject}
         isOpen={isModalOpen}
         onClose={closeModal}
+        initialTab={initialTab}
+        onTrackInvestment={onTrackInvestment}
       />
     </section>
   );

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -21,6 +21,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [isProjectModalOpen, setIsProjectModalOpen] = useState(false);
+  const [initialTab, setInitialTab] = useState<'overview' | 'invest'>('overview');
   const { theme, toggleTheme } = useTheme();
   const { user, isAuthenticated, logout } = useAuth();
 
@@ -75,8 +76,9 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
     setShowUserMenu(false);
   };
 
-  const handleProjectSelect = (project: Project) => {
+  const handleProjectSelect = (project: Project, tab: 'overview' | 'invest' = 'overview') => {
     setSelectedProject(project);
+    setInitialTab(tab);
     setIsProjectModalOpen(true);
   };
 
@@ -694,7 +696,10 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
         onClose={() => {
           setIsProjectModalOpen(false);
           setSelectedProject(null);
+          setInitialTab('overview');
         }}
+        initialTab={initialTab}
+        onTrackInvestment={() => setCurrentView('dashboard')}
       />
     </>
   );

--- a/src/components/ProjectCatalog.tsx
+++ b/src/components/ProjectCatalog.tsx
@@ -6,10 +6,15 @@ import { extendedProjects } from '../data/extendedProjects';
 import ProjectDetailModal from './ProjectDetailModal';
 import { Project } from '../types';
 
-const ProjectCatalog: React.FC = () => {
+interface ProjectCatalogProps {
+  onTrackInvestment?: () => void;
+}
+
+const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [initialTab, setInitialTab] = useState<'overview' | 'invest'>('overview');
   const [viewMode, setViewMode] = useState<'grid' | 'list' | 'cards'>('cards');
   const [showFilters, setShowFilters] = useState(false);
   const [showAllProjects, setShowAllProjects] = useState<string | null>(null);
@@ -29,14 +34,16 @@ const ProjectCatalog: React.FC = () => {
   const [fundingRange, setFundingRange] = useState<[number, number]>([0, 100]);
   const [sortBy, setSortBy] = useState<string>('trending');
 
-  const handleProjectClick = (project: Project) => {
+  const handleProjectClick = (project: Project, tab: 'overview' | 'invest' = 'overview') => {
     setSelectedProject(project);
+    setInitialTab(tab);
     setIsModalOpen(true);
   };
 
   const closeModal = () => {
     setIsModalOpen(false);
     setSelectedProject(null);
+    setInitialTab('overview');
   };
 
   // Filter options
@@ -370,8 +377,8 @@ const ProjectCatalog: React.FC = () => {
                   </div>
 
                   <div className="flex items-center gap-4">
-                    <button 
-                      onClick={() => handleProjectClick(featuredProjects[currentSlide])}
+                    <button
+                      onClick={() => handleProjectClick(featuredProjects[currentSlide], 'invest')}
                       className="flex items-center gap-3 px-8 py-4 bg-white text-black rounded-lg font-semibold text-lg hover:bg-gray-200 transition-all duration-300 hover:scale-105"
                     >
                       <Play className="w-6 h-6 fill-current" />
@@ -771,10 +778,12 @@ const ProjectCatalog: React.FC = () => {
       </div>
 
       {/* Project Detail Modal */}
-      <ProjectDetailModal 
+      <ProjectDetailModal
         project={selectedProject}
         isOpen={isModalOpen}
         onClose={closeModal}
+        initialTab={initialTab}
+        onTrackInvestment={onTrackInvestment}
       />
     </div>
   );
@@ -784,7 +793,7 @@ const ProjectCatalog: React.FC = () => {
 interface ProjectRowProps {
   title: string;
   projects: Project[];
-  onProjectClick: (project: Project) => void;
+  onProjectClick: (project: Project, tab?: 'overview' | 'invest') => void;
   onHeaderClick?: () => void;
   featured?: boolean;
   urgent?: boolean;
@@ -1050,7 +1059,10 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, onClick, featured, u
 
                 {/* Action Buttons */}
                 <div className="flex items-center gap-2 pt-2">
-                  <button className="flex-1 flex items-center justify-center gap-2 py-2 px-3 bg-white text-black rounded-lg font-semibold text-sm hover:bg-gray-200 transition-colors shadow-lg">
+                  <button
+                    onClick={() => handleProjectClick(project, 'invest')}
+                    className="flex-1 flex items-center justify-center gap-2 py-2 px-3 bg-white text-black rounded-lg font-semibold text-sm hover:bg-gray-200 transition-colors shadow-lg"
+                  >
                     <Play className="w-4 h-4 fill-current" />
                     Invest Now
                   </button>
@@ -1157,7 +1169,10 @@ const ListProjectCard: React.FC<ListProjectCardProps> = ({ project, onClick }) =
             )}
           </div>
           
-          <button className="px-6 py-2 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-lg font-medium hover:from-purple-500 hover:to-blue-500 transition-all duration-300">
+          <button
+            onClick={() => handleProjectClick(project, 'invest')}
+            className="px-6 py-2 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-lg font-medium hover:from-purple-500 hover:to-blue-500 transition-all duration-300"
+          >
             Invest Now
           </button>
         </div>

--- a/src/components/ProjectComparison.tsx
+++ b/src/components/ProjectComparison.tsx
@@ -25,9 +25,11 @@ import { extendedProjects } from '../data/extendedProjects';
 
 interface ProjectComparisonProps {
   initialProjects?: Project[];
+  onTrackInvestment?: () => void;
+  setCurrentView?: (view: 'home' | 'dashboard' | 'projects' | 'community' | 'merch' | 'profile' | 'admin' | 'portfolio' | 'compare' | 'news' | 'notifications' | 'search') => void;
 }
 
-const ProjectComparison: React.FC<ProjectComparisonProps> = ({ initialProjects }) => {
+const ProjectComparison: React.FC<ProjectComparisonProps> = ({ initialProjects, onTrackInvestment, setCurrentView }) => {
   const { theme } = useTheme();
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -848,6 +850,10 @@ const ProjectComparison: React.FC<ProjectComparisonProps> = ({ initialProjects }
         project={selectedProject}
         isOpen={isModalOpen}
         onClose={() => { setIsModalOpen(false); setSelectedProject(null); }}
+        onTrackInvestment={() => {
+          if (onTrackInvestment) onTrackInvestment();
+          setCurrentView && setCurrentView('dashboard');
+        }}
         initialTab="invest"
       />
     </div>

--- a/src/components/ProjectDetailModal.tsx
+++ b/src/components/ProjectDetailModal.tsx
@@ -33,9 +33,10 @@ interface ProjectDetailModalProps {
   isOpen: boolean;
   onClose: () => void;
   initialTab?: 'overview' | 'script' | 'cast' | 'perks' | 'invest';
+  onTrackInvestment?: () => void;
 }
 
-const ProjectDetailModal: React.FC<ProjectDetailModalProps> = ({ project, isOpen, onClose, initialTab = 'overview' }) => {
+const ProjectDetailModal: React.FC<ProjectDetailModalProps> = ({ project, isOpen, onClose, initialTab = 'overview', onTrackInvestment }) => {
   const [activeTab, setActiveTab] = useState<'overview' | 'script' | 'cast' | 'perks' | 'invest'>(initialTab);
   const [selectedPerkTier, setSelectedPerkTier] = useState<string>('supporter');
   const [investmentAmount, setInvestmentAmount] = useState<number>(25000);
@@ -1074,7 +1075,15 @@ TITLE CARD: "NEON NIGHTS"`,
                 <CheckCircle className="w-12 h-12 text-green-400 mx-auto" />
                 <p className="text-white text-lg font-bold">You're in!</p>
                 <p className="text-gray-300">Your name is now tied to the story.</p>
-                <button className="mt-2 px-4 py-2 rounded-lg bg-gradient-to-r from-purple-500 to-blue-500 text-white">Track Your Investment</button>
+                <button
+                  onClick={() => {
+                    if (onTrackInvestment) onTrackInvestment();
+                    onClose();
+                  }}
+                  className="mt-2 px-4 py-2 rounded-lg bg-gradient-to-r from-purple-500 to-blue-500 text-white"
+                >
+                  Track Your Investment
+                </button>
               </div>
             </motion.div>
           )}


### PR DESCRIPTION
## Summary
- add `onTrackInvestment` prop to `ProjectDetailModal`
- open investment tab from LiveProjects and ProjectCatalog buttons
- include bottom invest button in LiveProjects cards
- navigate to dashboard when tracking investments

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865ea5c00b0832f887ea6e361e15782