### PR TITLE
Fix mobile UI elements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,9 +102,9 @@ function AppContent() {
   };
 
   return (
-    <div className="min-h-screen transition-colors duration-300">
-      <Navigation 
-        currentView={currentView} 
+    <div className="min-h-screen transition-colors duration-300 overflow-x-hidden">
+      <Navigation
+        currentView={currentView}
         setCurrentView={handleViewChange}
         onAuthRequired={handleAuthRequired}
       />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -477,7 +477,7 @@ const Hero: React.FC<HeroProps> = ({ setCurrentView }) => {
             </div>
 
             {/* Main Stats Grid with Enhanced Gradient Awareness */}
-            <div className="relative z-10 grid grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+            <div className="relative z-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
               {[
                 {
                   icon: Target,

--- a/src/components/MobileBottomBar.tsx
+++ b/src/components/MobileBottomBar.tsx
@@ -27,7 +27,7 @@ const MobileBottomBar: React.FC<Props> = ({ currentView, setCurrentView, onAuthR
   };
 
   return (
-    <nav className="fixed bottom-0 inset-x-0 z-50 bg-black/80 backdrop-blur-md md:hidden">
+    <nav className="fixed bottom-0 inset-x-0 z-50 md:hidden backdrop-blur-lg bg-white/30 dark:bg-gray-900/40 border-t border-white/20 dark:border-white/10">
       <div className="flex justify-around py-2">
         {navItems.map((item) => (
           <button

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -382,7 +382,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: -100, opacity: 0 }}
             transition={{ duration: 0.3, ease: "easeOut" }}
-            className="fixed left-6 top-0 bottom-0 z-50 flex items-center"
+            className="hidden md:flex fixed left-6 top-0 bottom-0 z-50 items-center"
           >
             {/* Sidebar Container - Clean icon column only */}
             <div className="flex flex-col items-center space-y-6 w-16 py-8 group">

--- a/src/components/ProjectCatalog.tsx
+++ b/src/components/ProjectCatalog.tsx
@@ -292,7 +292,7 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
     <div className="min-h-screen bg-black">
       {/* Full-Screen Auto-Sliding Hero Carousel */}
       {!searchTerm && !showAllProjects && (
-        <div className="relative h-screen overflow-hidden">
+        <div className="hidden md:block relative h-screen overflow-hidden">
           <AnimatePresence mode="wait">
             <motion.div
               key={currentSlide}


### PR DESCRIPTION
## Summary
- hide the sidebar on small screens
- give the mobile bottom nav a glassmorphism style
- remove hero carousel on mobile
- adjust hero stats grid for small devices
- prevent horizontal scrolling

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6866006df754832fbca9d5eeab557c59