### PR TITLE
Improve mobile layout

### DIFF
--- a/src/components/Community.tsx
+++ b/src/components/Community.tsx
@@ -631,7 +631,7 @@ const Community: React.FC = () => {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.2 }}
-          className={`flex items-center gap-2 p-2 rounded-2xl backdrop-blur-xl border mb-8 ${
+          className={`flex items-center gap-2 p-2 rounded-2xl backdrop-blur-xl border mb-8 overflow-x-auto justify-around md:justify-start ${
             theme === 'light'
               ? 'light-glass-header'
               : 'bg-white/10 border-white/20'
@@ -648,7 +648,7 @@ const Community: React.FC = () => {
               }`}
             >
               <tab.icon className="w-5 h-5" />
-              {tab.label}
+              <span className="hidden md:inline">{tab.label}</span>
             </button>
           ))}
         </motion.div>

--- a/src/components/MobileBottomBar.tsx
+++ b/src/components/MobileBottomBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Home, Film, Users, User, LogIn } from 'lucide-react';
+import { Home, Film, Users, User, LogIn, BarChart3 } from 'lucide-react';
 import { useAuth } from './auth/AuthProvider';
 
 interface Props {
@@ -14,6 +14,7 @@ const MobileBottomBar: React.FC<Props> = ({ currentView, setCurrentView, onAuthR
   const navItems = [
     { id: 'home' as const, icon: Home, label: 'Home' },
     { id: 'projects' as const, icon: Film, label: 'Browse' },
+    { id: 'dashboard' as const, icon: BarChart3, label: 'Dashboard' },
     { id: 'community' as const, icon: Users, label: 'Community' },
     { id: 'profile' as const, icon: User, label: 'Profile', requiresAuth: true }
   ];

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -95,9 +95,9 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
             className="fixed top-0 left-0 right-0 z-50"
           >
             <div className="max-w-7xl mx-auto px-8 py-6">
-              <div className="flex items-center justify-between">
+              <div className="relative flex items-center justify-between">
                 {/* Logo - Much bigger size, no animations */}
-                <div className="flex items-center gap-4">
+                <div className="hidden md:flex items-center gap-4">
                   <div className="w-24 h-24 flex items-center justify-center">
                     <img 
                       src="/Improved Logo-01.png" 
@@ -154,7 +154,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
                   ))}
                   
                   {/* More Menu Dropdown */}
-                  <div className="relative">
+                  <div className="relative hidden md:block">
                     <motion.button
                       onClick={() => setShowMoreMenu(!showMoreMenu)}
                       className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-all duration-[3000ms] ${
@@ -221,9 +221,9 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
                 </div>
 
                 {/* Right Side Actions */}
-                <div className="flex items-center gap-4">
+                <div className="hidden md:flex items-center gap-4">
                   {/* Search Button */}
-                  <div className="relative">
+                  <div className="relative hidden md:block">
                     <SearchBar
                       onSelectProject={handleProjectSelect}
                       onViewAllResults={() => {
@@ -331,7 +331,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
                 </div>
 
                 {/* Mobile Menu */}
-                <div className="md:hidden flex items-center gap-4">
+                <div className="md:hidden flex items-center gap-4 absolute left-1/2 -translate-x-1/2">
                   {mainNavItems.map((item, index) => (
                     <motion.button
                       key={item.id}
@@ -463,7 +463,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
                 ))}
 
                 {/* More Menu Button */}
-                <div className="relative">
+                <div className="relative hidden md:block">
                   <motion.button
                     onClick={() => setShowMoreMenu(!showMoreMenu)}
                     className={`relative flex items-center justify-center w-12 h-12 rounded-xl transition-all duration-[3000ms] ${
@@ -552,7 +552,7 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
                 </div>
 
                 {/* Notification Button */}
-                <div className="relative">
+                <div className="relative hidden md:block">
                   <motion.button
                       onClick={() => setCurrentView('notifications')}
                       className={`relative flex items-center justify-center w-12 h-12 rounded-xl transition-all duration-[3000ms] ${

--- a/src/components/ProjectCatalog.tsx
+++ b/src/components/ProjectCatalog.tsx
@@ -454,7 +454,7 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
       <div className="max-w-7xl mx-auto px-6 py-8">
         <div className="flex flex-col lg:flex-row gap-4 mb-8">
           {/* Search Bar */}
-          <div className="relative flex-1">
+          <div className="relative flex-1 hidden md:block">
             <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-gray-400 w-6 h-6" />
             <input
               type="text"
@@ -473,7 +473,7 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
                 viewMode === 'cards' ? 'bg-red-600 text-white' : 'text-gray-400 hover:text-white'
               }`}
             >
-              <Grid3X3 className="w-5 h-5" />
+              <Grid3X3 className="w-6 h-6 md:w-5 md:h-5" />
             </button>
             <button
               onClick={() => setViewMode('grid')}
@@ -481,7 +481,7 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
                 viewMode === 'grid' ? 'bg-red-600 text-white' : 'text-gray-400 hover:text-white'
               }`}
             >
-              <Grid3X3 className="w-5 h-5" />
+              <Grid3X3 className="w-6 h-6 md:w-5 md:h-5" />
             </button>
             <button
               onClick={() => setViewMode('list')}
@@ -489,7 +489,7 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
                 viewMode === 'list' ? 'bg-red-600 text-white' : 'text-gray-400 hover:text-white'
               }`}
             >
-              <List className="w-5 h-5" />
+              <List className="w-6 h-6 md:w-5 md:h-5" />
             </button>
           </div>
 

--- a/src/components/ProjectDetailModal.tsx
+++ b/src/components/ProjectDetailModal.tsx
@@ -295,11 +295,6 @@ TITLE CARD: "NEON NIGHTS"`,
 
           {/* Modal */}
           <motion.div
-            drag={isMobile ? 'y' : false}
-            dragConstraints={{ top: 0, bottom: 0 }}
-            onDragEnd={(_, info) => {
-              if (isMobile && info.point.y > 100) onClose();
-            }}
             initial={isMobile ? { y: '100%' } : { opacity: 0, scale: 0.9, y: 50 }}
             animate={isMobile ? { y: 0 } : { opacity: 1, scale: 1, y: 0 }}
             exit={isMobile ? { y: '100%' } : { opacity: 0, scale: 0.9, y: 50 }}


### PR DESCRIPTION
## Summary
- center mobile top nav items
- hide nav search bar on small screens
- add Dashboard shortcut to mobile bottom bar
- show only icons for community tabs on small screens
- hide catalog search bar on mobile and enlarge view buttons
- stop modal from closing on scroll

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68660c7e9714832f970feb417a96c2d5