### PR TITLE
Improve mobile layouts

### DIFF
--- a/src/components/Community.tsx
+++ b/src/components/Community.tsx
@@ -928,10 +928,10 @@ const Community: React.FC = () => {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}
               transition={{ duration: 0.4 }}
-              className="grid lg:grid-cols-4 gap-6"
+              className="grid grid-cols-3 lg:grid-cols-4 gap-6"
             >
               {/* Channel List */}
-              <div className={`lg:col-span-1 p-6 rounded-2xl backdrop-blur-xl border ${
+              <div className={`col-span-1 lg:col-span-1 p-6 rounded-2xl backdrop-blur-xl border ${
                 theme === 'light'
                   ? 'light-glass-header'
                   : 'bg-white/10 border-white/20'
@@ -965,7 +965,7 @@ const Community: React.FC = () => {
               </div>
 
               {/* Chat Area */}
-              <div className={`lg:col-span-3 p-6 rounded-2xl backdrop-blur-xl border ${
+              <div className={`col-span-2 lg:col-span-3 p-6 rounded-2xl backdrop-blur-xl border ${
                 theme === 'light'
                   ? 'light-glass-header'
                   : 'bg-white/10 border-white/20'
@@ -1057,10 +1057,10 @@ const Community: React.FC = () => {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -20 }}
               transition={{ duration: 0.4 }}
-              className="grid lg:grid-cols-4 gap-6"
+              className="grid grid-cols-3 lg:grid-cols-4 gap-6"
             >
               <div
-                className={`lg:col-span-1 p-6 rounded-2xl backdrop-blur-xl border ${
+                className={`col-span-1 lg:col-span-1 p-6 rounded-2xl backdrop-blur-xl border ${
                   theme === 'light' ? 'light-glass-header' : 'bg-white/10 border-white/20'
                 }`}
               >
@@ -1087,7 +1087,7 @@ const Community: React.FC = () => {
               </div>
 
               <div
-                className={`lg:col-span-3 p-6 rounded-2xl backdrop-blur-xl border ${
+                className={`col-span-2 lg:col-span-3 p-6 rounded-2xl backdrop-blur-xl border ${
                   theme === 'light' ? 'light-glass-header' : 'bg-white/10 border-white/20'
                 }`}
               >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -389,11 +389,27 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
                   whileHover={{ scale: 1.1 }}
                   whileTap={{ scale: 0.9 }}
                 >
-                  {theme === 'light' ? (
-                    <Moon className="w-5 h-5 drop-shadow-lg" />
-                  ) : (
-                    <Sun className="w-5 h-5 drop-shadow-lg" />
-                  )}
+                  <AnimatePresence mode="wait" initial={false}>
+                    {theme === 'light' ? (
+                      <motion.span
+                        key="moon"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                      >
+                        <Moon className="w-5 h-5 drop-shadow-lg" />
+                      </motion.span>
+                    ) : (
+                      <motion.span
+                        key="sun"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                      >
+                        <Sun className="w-5 h-5 drop-shadow-lg" />
+                      </motion.span>
+                    )}
+                  </AnimatePresence>
                 </motion.button>
               </div>
               </div>

--- a/src/components/ProjectDetailModal.tsx
+++ b/src/components/ProjectDetailModal.tsx
@@ -384,7 +384,7 @@ TITLE CARD: "NEON NIGHTS"`,
             {/* Content */}
             <div className="flex">
               {/* Scrollable Sidebar Navigation */}
-              <div className={`${isMobile ? 'w-16' : 'w-80'} border-r flex flex-col ${
+              <div className={`${isMobile ? 'w-16 items-center' : 'w-80'} border-r flex flex-col ${
                 theme === 'light'
                   ? 'bg-white/30 border-gray-200'
                   : 'bg-black/30 border-white/10'
@@ -425,6 +425,7 @@ TITLE CARD: "NEON NIGHTS"`,
                     </div>
 
                     {/* Quick Stats */}
+                    {!isMobile && (
                     <div className={`p-4 rounded-xl border ${
                       theme === 'light'
                         ? 'bg-white/50 border-gray-200'
@@ -468,8 +469,10 @@ TITLE CARD: "NEON NIGHTS"`,
                         )}
                       </div>
                     </div>
+                    )}
 
                     {/* Investment Tiers Preview */}
+                    {!isMobile && (
                     <div className={`p-4 rounded-xl border ${
                       theme === 'light'
                         ? 'bg-white/50 border-gray-200'
@@ -499,6 +502,7 @@ TITLE CARD: "NEON NIGHTS"`,
                         </button>
                       </div>
                     </div>
+                    )}
 
                     {/* Project Tags */}
                     <div>

--- a/src/index.css
+++ b/src/index.css
@@ -613,6 +613,7 @@
   .modal-content {
     overflow-y: auto;
     max-height: 100vh;
+    -webkit-overflow-scrolling: touch;
   }
 
   /* Prevent background scroll when modal is open */


### PR DESCRIPTION
## Summary
- hide Quick Stats and Investment Tiers in project modal on small screens
- center sidebar icons for mobile layout and make modal content scroll smoothly
- keep two‑column layout for Channels and Friends on small screens
- add fade animation for theme toggle icon on mobile

## Testing
- `npm install`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686650ffdf84832f884d5ed5ba88c8ae