### PR TITLE
Improve mobile layout and checkout UX

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -205,16 +205,16 @@ const Dashboard: React.FC = () => {
         </motion.div>
 
         {/* Tabs */}
-        <div className="flex flex-wrap gap-4 mb-8">
+        <div className="flex flex-wrap gap-4 mb-8 max-md:grid max-md:grid-cols-2">
           {tabs.map((tab) => (
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id as any)}
-              className={`flex items-center gap-2 px-6 py-3 rounded-xl font-medium transition-all duration-300 ${
+              className={`flex items-center gap-2 px-6 py-3 rounded-xl font-medium transition-all duration-300 max-md:w-full ${
                 activeTab === tab.id
                   ? 'bg-gradient-to-r from-purple-500 to-blue-500 text-white shadow-lg'
                   : 'bg-white/10 text-gray-300 hover:bg-white/20 hover:text-white'
-              }`}
+              } ${tab.id === 'portfolio' ? 'max-md:col-span-2' : ''}`}
             >
               <tab.icon className="w-5 h-5" />
               {tab.label}

--- a/src/components/PortfolioAnalytics.tsx
+++ b/src/components/PortfolioAnalytics.tsx
@@ -83,11 +83,13 @@ const PortfolioAnalytics: React.FC<PortfolioAnalyticsProps> = () => {
   const recommendation = "Consider diversifying with more Web Series investments to balance your portfolio. Recent trends show higher ROI in Regional content.";
 
   return (
-    <div className={`min-h-screen pt-20 pb-[100px] transition-all duration-[3000ms] ${
-      theme === 'light'
-        ? 'bg-gradient-to-br from-gray-50 to-white'
-        : 'bg-gradient-to-br from-black via-gray-900 to-purple-900'
-    }`}>
+    <div
+      className={`min-h-screen pt-20 pb-[100px] transition-all duration-[3000ms] max-md:h-[calc(100vh-80px)] max-md:overflow-y-auto max-md:scroll-smooth ${
+        theme === 'light'
+          ? 'bg-gradient-to-br from-gray-50 to-white'
+          : 'bg-gradient-to-br from-black via-gray-900 to-purple-900'
+      }`}
+    >
       <div className="max-w-7xl mx-auto px-6 py-8">
         {/* Header */}
         <motion.div

--- a/src/components/ProjectCatalog.tsx
+++ b/src/components/ProjectCatalog.tsx
@@ -28,6 +28,7 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
   const [isPaused, setIsPaused] = useState(false);
   const autoSlideRef = useRef<NodeJS.Timeout | null>(null);
   const pauseTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [touchStartX, setTouchStartX] = useState(0);
   
   // Filter states
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
@@ -293,6 +294,32 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
 
   return (
     <div className="min-h-screen bg-black pb-[100px]">
+      {/* Mobile Hero Carousel */}
+      {!searchTerm && !showAllProjects && (
+        <div className="md:hidden relative h-72 overflow-hidden" onTouchStart={(e) => setTouchStartX(e.touches[0].clientX)} onTouchEnd={(e) => { const diff = e.changedTouches[0].clientX - touchStartX; if (Math.abs(diff) > 50) diff > 0 ? prevSlide() : nextSlide(); }}>
+          <AnimatePresence mode="wait">
+            <motion.img
+              key={`m-${currentSlide}`}
+              src={featuredProjects[currentSlide]?.poster}
+              alt={featuredProjects[currentSlide]?.title}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.5 }}
+              className="absolute inset-0 w-full h-full object-cover"
+            />
+          </AnimatePresence>
+          <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-2">
+            {featuredProjects.map((_, index) => (
+              <button
+                key={`md-${index}`}
+                onClick={() => handleSlideChange(index)}
+                className={`w-2 h-2 rounded-full transition-colors duration-300 ${index === currentSlide ? 'bg-white' : 'bg-white/40'}`}
+              />
+            ))}
+          </div>
+        </div>
+      )}
       {/* Full-Screen Auto-Sliding Hero Carousel */}
       {!searchTerm && !showAllProjects && (
         <div className="hidden md:block relative h-screen overflow-hidden">

--- a/src/components/ProjectDetailModal.tsx
+++ b/src/components/ProjectDetailModal.tsx
@@ -45,6 +45,11 @@ const ProjectDetailModal: React.FC<ProjectDetailModalProps> = ({ project, isOpen
   const [showSuccess, setShowSuccess] = useState(false);
   const [investStatus, setInvestStatus] = useState<'idle' | 'loading' | 'success'>('idle');
   const [showMobileInvest, setShowMobileInvest] = useState(false);
+  const [paymentMethod, setPaymentMethod] = useState<'upi' | 'card'>('upi');
+  const [upiId, setUpiId] = useState('');
+  const [cardNumber, setCardNumber] = useState('');
+  const [cardExpiry, setCardExpiry] = useState('');
+  const [cardCvv, setCardCvv] = useState('');
   const { theme } = useTheme();
   const { toast } = useToast();
   const isMobile = useIsMobile();
@@ -1134,10 +1139,54 @@ TITLE CARD: "NEON NIGHTS"`,
                     onChange={(e) => setInvestmentAmount(Number(e.target.value))}
                     className="w-full px-4 py-3 rounded-xl border border-white/20 bg-white/10 text-white mb-6"
                   />
+                  <h4 className="text-white text-lg font-semibold mb-2">Payment Method</h4>
+                  <select
+                    value={paymentMethod}
+                    onChange={(e) => setPaymentMethod(e.target.value as 'upi' | 'card')}
+                    className="w-full px-4 py-3 rounded-xl border border-white/20 bg-white/10 text-white mb-4"
+                  >
+                    <option value="upi">UPI</option>
+                    <option value="card">Card</option>
+                  </select>
+                  {paymentMethod === 'upi' ? (
+                    <input
+                      type="text"
+                      placeholder="UPI ID"
+                      value={upiId}
+                      onChange={(e) => setUpiId(e.target.value)}
+                      className="w-full px-4 py-3 rounded-xl border border-white/20 bg-white/10 text-white mb-4"
+                    />
+                  ) : (
+                    <div className="space-y-4">
+                      <input
+                        type="text"
+                        placeholder="Card Number"
+                        value={cardNumber}
+                        onChange={(e) => setCardNumber(e.target.value)}
+                        className="w-full px-4 py-3 rounded-xl border border-white/20 bg-white/10 text-white"
+                      />
+                      <div className="flex gap-4">
+                        <input
+                          type="text"
+                          placeholder="MM/YY"
+                          value={cardExpiry}
+                          onChange={(e) => setCardExpiry(e.target.value)}
+                          className="flex-1 px-4 py-3 rounded-xl border border-white/20 bg-white/10 text-white"
+                        />
+                        <input
+                          type="text"
+                          placeholder="CVV"
+                          value={cardCvv}
+                          onChange={(e) => setCardCvv(e.target.value)}
+                          className="w-20 px-4 py-3 rounded-xl border border-white/20 bg-white/10 text-white"
+                        />
+                      </div>
+                    </div>
+                  )}
                   <button
                     onClick={handleInvest}
                     disabled={investStatus === 'loading'}
-                    className="w-full h-12 rounded-xl bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold text-lg"
+                    className="mt-6 w-full h-12 rounded-xl bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold text-lg"
                   >
                     Pay
                   </button>
@@ -1168,13 +1217,17 @@ TITLE CARD: "NEON NIGHTS"`,
         <AnimatePresence>
           {investStatus === 'success' && (
             <motion.div
-              initial={{ y: 50, opacity: 0 }}
-              animate={{ y: 0, opacity: 1 }}
+              initial={{ y: 50, opacity: 0, scale: 0.9 }}
+              animate={{ y: 0, opacity: 1, scale: 1 }}
               exit={{ opacity: 0 }}
               className="fixed bottom-24 left-1/2 -translate-x-1/2 z-[9999] px-4 py-3 rounded-xl bg-gray-900 text-white flex items-center gap-2"
             >
-              <CheckCircle className="w-6 h-6 text-green-400" />
-              <span>Your investment is confirmed!</span>
+              <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} transition={{ type: 'spring', stiffness: 300, damping: 20 }}>
+                <CheckCircle className="w-6 h-6 text-green-400" />
+              </motion.div>
+              <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.5 }}>
+                Your investment is confirmed!
+              </motion.span>
             </motion.div>
           )}
         </AnimatePresence>


### PR DESCRIPTION
## Summary
- center the Portfolio tab on dashboard for mobile users
- allow scrolling for Portfolio Analytics on small screens
- add a swipeable hero carousel for phones
- show checkout modal with UPI or card inputs
- animate confirmation after investment

## Testing
- `npm run lint` *(fails: many unused variables)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68666bb40d78832faf7cbb35d9ee9d50