### PR TITLE
Improve mobile carousel and notifications

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -369,18 +369,12 @@ const Navigation: React.FC<NavigationProps> = ({ currentView, setCurrentView, on
                 </motion.button>
 
                 {/* Notifications */}
-                <motion.button
-                  onClick={() => setCurrentView('notifications')}
-                  className={`p-2 rounded-lg transition-all duration-[3000ms] ${
-                    currentView === 'notifications'
-                      ? 'text-cyan-400'
-                      : `${theme === 'light' ? 'text-gray-600 hover:text-gray-900' : 'text-gray-300 hover:text-white'}`
-                  }`}
-                  whileHover={{ scale: 1.1 }}
-                  whileTap={{ scale: 0.9 }}
-                >
-                  <Bell className="w-5 h-5 drop-shadow-lg" />
-                </motion.button>
+                <div className="relative">
+                  <NotificationDropdown
+                    onViewAll={() => setCurrentView('notifications')}
+                    maxItems={3}
+                  />
+                </div>
 
                 {/* Theme Toggle */}
                 <motion.button

--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -83,9 +83,10 @@ const mockNotifications = [
 
 interface NotificationDropdownProps {
   onViewAll: () => void;
+  maxItems?: number;
 }
 
-const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ onViewAll }) => {
+const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ onViewAll, maxItems = 5 }) => {
   const { theme, toggleTheme } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const [notifications, setNotifications] = useState(mockNotifications);
@@ -102,9 +103,15 @@ const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ onViewAll }
       }
     };
 
+    const handleScroll = () => {
+      setIsOpen(false);
+    };
+
     document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('scroll', handleScroll, { passive: true });
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('scroll', handleScroll);
     };
   }, []);
 
@@ -236,7 +243,7 @@ const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ onViewAll }
             {/* Notification List */}
             <div className="max-h-96 overflow-y-auto">
               {notifications.length > 0 ? (
-                notifications.slice(0, 5).map((notification) => (
+                notifications.slice(0, maxItems).map((notification) => (
                   <div 
                     key={notification.id}
                     onClick={() => markAsRead(notification.id)}

--- a/src/components/ProjectCatalog.tsx
+++ b/src/components/ProjectCatalog.tsx
@@ -196,7 +196,7 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
     if (isAutoPlaying && !isPaused) {
       autoSlideRef.current = setInterval(() => {
         setCurrentSlide((prev) => (prev + 1) % featuredProjects.length);
-      }, 3000);
+      }, 2500);
     }
 
     return () => {
@@ -296,24 +296,43 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
     <div className="min-h-screen bg-black pb-[100px]">
       {/* Mobile Hero Carousel */}
       {!searchTerm && !showAllProjects && (
-        <div className="md:hidden relative h-72 overflow-hidden" onTouchStart={(e) => setTouchStartX(e.touches[0].clientX)} onTouchEnd={(e) => { const diff = e.changedTouches[0].clientX - touchStartX; if (Math.abs(diff) > 50) diff > 0 ? prevSlide() : nextSlide(); }}>
+        <div
+          className="md:hidden relative h-72 overflow-hidden"
+          onTouchStart={(e) => setTouchStartX(e.touches[0].clientX)}
+          onTouchEnd={(e) => {
+            const diff = e.changedTouches[0].clientX - touchStartX;
+            if (Math.abs(diff) > 50) diff > 0 ? prevSlide() : nextSlide();
+          }}
+          onClick={() => handleProjectClick(featuredProjects[currentSlide])}
+        >
           <AnimatePresence mode="wait">
             <motion.img
               key={`m-${currentSlide}`}
               src={featuredProjects[currentSlide]?.poster}
               alt={featuredProjects[currentSlide]?.title}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.5 }}
+              initial={{ x: 150, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              exit={{ x: -150, opacity: 0 }}
+              transition={{ duration: 0.6, ease: 'easeInOut' }}
               className="absolute inset-0 w-full h-full object-cover"
             />
           </AnimatePresence>
+          <div className="absolute top-0 left-0 w-full p-3 bg-gradient-to-b from-black/70 via-black/40 to-transparent">
+            <h3 className="text-white text-base font-semibold">
+              {featuredProjects[currentSlide]?.title}
+            </h3>
+            <span className="text-xs text-gray-300">
+              {featuredProjects[currentSlide]?.genre}
+            </span>
+          </div>
           <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-2">
             {featuredProjects.map((_, index) => (
               <button
                 key={`md-${index}`}
-                onClick={() => handleSlideChange(index)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleSlideChange(index);
+                }}
                 className={`w-2 h-2 rounded-full transition-colors duration-300 ${index === currentSlide ? 'bg-white' : 'bg-white/40'}`}
               />
             ))}


### PR DESCRIPTION
## Summary
- tweak project carousel auto-slide timing and slide animation
- show slide overlay with title and genre and allow click to open modal
- fix NotificationDropdown to allow customizing max items and close on scroll
- use NotificationDropdown on mobile nav

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686674a1931c832faf8ce6049a4ba27f