### PR TITLE
Improve carousel text and mobile notification panel

### DIFF
--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -22,6 +22,7 @@ import {
   Moon
 } from 'lucide-react';
 import { useTheme } from './ThemeProvider';
+import useIsMobile from '../hooks/useIsMobile';
 
 // Mock notification data
 const mockNotifications = [
@@ -88,6 +89,7 @@ interface NotificationDropdownProps {
 
 const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ onViewAll, maxItems = 5 }) => {
   const { theme, toggleTheme } = useTheme();
+  const isMobile = useIsMobile();
   const [isOpen, setIsOpen] = useState(false);
   const [notifications, setNotifications] = useState(mockNotifications);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -201,14 +203,16 @@ const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ onViewAll, 
       <AnimatePresence>
         {isOpen && (
           <motion.div
-            initial={{ opacity: 0, y: 10, scale: 0.95 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 10, scale: 0.95 }}
-            transition={{ duration: 0.2 }}
-            className={`absolute right-0 mt-2 w-80 rounded-xl border shadow-xl z-50 overflow-hidden ${
-              theme === 'light'
-                ? 'bg-white border-gray-200'
-                : 'bg-gray-900 border-gray-700'
+            initial={isMobile ? { x: '-100%', opacity: 0 } : { opacity: 0, y: 10, scale: 0.95 }}
+            animate={isMobile ? { x: 0, opacity: 1 } : { opacity: 1, y: 0, scale: 1 }}
+            exit={isMobile ? { x: '-100%', opacity: 0 } : { opacity: 0, y: 10, scale: 0.95 }}
+            transition={{ duration: 0.3 }}
+            className={`${
+              isMobile
+                ? 'fixed left-0 top-0 h-1/2 w-full sm:w-[90%] rounded-r-xl'
+                : 'absolute right-0 mt-2 w-80 rounded-xl'
+            } border shadow-xl z-50 overflow-hidden ${
+              theme === 'light' ? 'bg-white border-gray-200' : 'bg-gray-900 border-gray-700'
             }`}
           >
             {/* Header */}
@@ -241,7 +245,7 @@ const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ onViewAll, 
             </div>
 
             {/* Notification List */}
-            <div className="max-h-96 overflow-y-auto">
+            <div className="h-full overflow-y-auto">
               {notifications.length > 0 ? (
                 notifications.slice(0, maxItems).map((notification) => (
                   <div 

--- a/src/components/ProjectCatalog.tsx
+++ b/src/components/ProjectCatalog.tsx
@@ -317,13 +317,13 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
               className="absolute inset-0 w-full h-full object-cover"
             />
           </AnimatePresence>
-          <div className="absolute top-0 left-0 w-full p-3 bg-gradient-to-b from-black/70 via-black/40 to-transparent">
-            <h3 className="text-white text-base font-semibold">
+          <div
+            className="absolute left-1/2 -translate-x-1/2 px-3 py-2 bg-black/60 backdrop-blur-sm rounded text-center w-11/12"
+            style={{ bottom: '35px' }}
+          >
+            <h3 className="text-white text-sm font-semibold line-clamp-2">
               {featuredProjects[currentSlide]?.title}
             </h3>
-            <span className="text-xs text-gray-300">
-              {featuredProjects[currentSlide]?.genre}
-            </span>
           </div>
           <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-2">
             {featuredProjects.map((_, index) => (


### PR DESCRIPTION
## Summary
- center carousel title overlay and move to bottom
- add mobile slide-in style to notification dropdown

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686677c78690832fb1786e17a1dc3e8d