### PR TITLE
Fix mobile overlay and notification pane

### DIFF
--- a/src/components/NotificationDropdown.tsx
+++ b/src/components/NotificationDropdown.tsx
@@ -205,7 +205,7 @@ const NotificationDropdown: React.FC<NotificationDropdownProps> = ({ onViewAll, 
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 10, scale: 0.95 }}
             transition={{ duration: 0.2 }}
-            className={`absolute right-0 mt-2 w-80 rounded-xl border shadow-xl z-50 overflow-hidden ${
+            className={`fixed md:absolute top-16 md:top-auto right-2 md:right-0 mt-0 md:mt-2 w-80 rounded-xl border shadow-xl z-50 overflow-hidden ${
               theme === 'light'
                 ? 'bg-white border-gray-200'
                 : 'bg-gray-900 border-gray-700'

--- a/src/components/ProjectCatalog.tsx
+++ b/src/components/ProjectCatalog.tsx
@@ -317,7 +317,7 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
               className="absolute inset-0 w-full h-full object-cover"
             />
           </AnimatePresence>
-          <div className="absolute top-0 left-0 w-full p-3 bg-gradient-to-b from-black/70 via-black/40 to-transparent">
+          <div className="absolute bottom-12 left-0 w-full p-3 text-center flex flex-col items-center bg-gradient-to-t from-black/70 via-black/40 to-transparent">
             <h3 className="text-white text-base font-semibold">
               {featuredProjects[currentSlide]?.title}
             </h3>


### PR DESCRIPTION
## Summary
- reposition mobile carousel overlay to bottom center
- fix notification dropdown to align to the right edge on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667b1f896c832f9b49cee5c7ce8470