### PR TITLE
Add swipe-to-invest feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "circles-landing-page",
       "version": "0.0.0",
       "dependencies": {
+        "canvas-confetti": "^1.9.3",
         "framer-motion": "^10.16.16",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
@@ -2557,6 +2558,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chai": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "canvas-confetti": "^1.9.3",
     "framer-motion": "^10.16.16",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",

--- a/src/components/LiveProjects.tsx
+++ b/src/components/LiveProjects.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Film, Music, Clock, Users, TrendingUp, ArrowRight } from 'lucide-react';
+import SwipeToInvest from './SwipeToInvest';
 import AnimatedNumber from './AnimatedNumber';
 import { extendedProjects } from '../data/extendedProjects';
 import ProjectDetailModal from './ProjectDetailModal';
@@ -195,19 +196,12 @@ const LiveProjects: React.FC<LiveProjectsProps> = ({ onViewAll, onTrackInvestmen
                   </div>
                 </div>
 
-                <button
-                  onClick={() => handleProjectClick(project, 'invest')}
-                  className={`w-full py-3 px-6 rounded-xl font-semibold transition-all duration-300 group ${
-                    project.type === 'film'
-                      ? 'bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white'
-                      : 'bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-500 hover:to-cyan-500 text-white'
-                  } hover:scale-105 hover:shadow-lg`}
-                >
-                  <span className="flex items-center justify-center gap-2">
-                    Invest Now
-                    <ArrowRight className="w-4 h-4 group-hover:translate-x-1 transition-transform" />
-                  </span>
-                </button>
+                <div className="w-full">
+                  <SwipeToInvest
+                    amount={25000}
+                    onConfirm={() => handleProjectClick(project, 'invest')}
+                  />
+                </div>
 
               </div>
             </motion.div>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import PixelCard from './PixelCard';
-import { 
-  Film, 
-  Music, 
-  Tv, 
+import {
+  Film,
+  Music,
+  Tv,
   Star, 
   Clock, 
   Users, 
@@ -16,6 +16,7 @@ import {
   ArrowRight,
   Award
 } from 'lucide-react';
+import SwipeToInvest from './SwipeToInvest';
 import { Project } from '../types';
 
 interface ProjectCardProps {
@@ -236,10 +237,9 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
                   >
                     <Play className="w-4 h-4" />
                   </a>
-                  <button className="flex-1 flex items-center justify-center gap-2 py-2 px-3 bg-white text-black rounded-lg font-semibold text-sm hover:bg-gray-200 transition-colors">
-                    <ArrowRight className="w-4 h-4" />
-                    Invest Now
-                  </button>
+                  <div className="flex-1">
+                    <SwipeToInvest amount={25000} onConfirm={onClick} />
+                  </div>
                   <button className="p-2 bg-gray-600/80 text-white rounded-lg hover:bg-gray-600 transition-colors">
                     <Plus className="w-4 h-4" />
                   </button>

--- a/src/components/ProjectCatalog.tsx
+++ b/src/components/ProjectCatalog.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import PixelCard from './PixelCard';
 import { Film, Music, Tv, Search, Star, Clock, Users, TrendingUp, ChevronLeft, ChevronRight, Play, Plus, Info, Siren as Fire, Award, Globe, Filter, Grid3X3, List, SlidersHorizontal, X, Calendar, DollarSign, MapPin, Heart, Share2, Bookmark, ArrowRight, Eye } from 'lucide-react';
+import SwipeToInvest from './SwipeToInvest';
 import { extendedProjects } from '../data/extendedProjects';
 import ProjectDetailModal from './ProjectDetailModal';
 import { Project } from '../types';
@@ -426,13 +427,12 @@ const ProjectCatalog: React.FC<ProjectCatalogProps> = ({ onTrackInvestment }) =>
                   </div>
 
                   <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-4">
-                    <button
-                      onClick={() => handleProjectClick(featuredProjects[currentSlide], 'invest')}
-                      className="flex items-center gap-3 px-8 py-4 bg-white text-black rounded-lg font-semibold text-lg hover:bg-gray-200 transition-all duration-300 hover:scale-105"
-                    >
-                      <Play className="w-6 h-6 fill-current" />
-                      Invest Now
-                    </button>
+                    <div className="flex-1 sm:flex-none">
+                      <SwipeToInvest
+                        amount={25000}
+                        onConfirm={() => handleProjectClick(featuredProjects[currentSlide], 'invest')}
+                      />
+                    </div>
                     
                     <button 
                       onClick={() => handleProjectClick(featuredProjects[currentSlide])}
@@ -1128,13 +1128,12 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ project, onClick, featured, u
 
                 {/* Action Buttons */}
                 <div className="flex items-center gap-2 pt-2">
-                  <button
-                    onClick={() => handleProjectClick(project, 'invest')}
-                    className="flex-1 flex items-center justify-center gap-2 py-2 px-3 bg-white text-black rounded-lg font-semibold text-sm hover:bg-gray-200 transition-colors shadow-lg"
-                  >
-                    <Play className="w-4 h-4 fill-current" />
-                    Invest Now
-                  </button>
+                  <div className="flex-1">
+                    <SwipeToInvest
+                      amount={25000}
+                      onConfirm={() => handleProjectClick(project, 'invest')}
+                    />
+                  </div>
                   <button className="p-2 bg-gray-800/80 text-white rounded-lg hover:bg-gray-700 transition-colors backdrop-blur-sm">
                     <Plus className="w-4 h-4" />
                   </button>
@@ -1238,12 +1237,12 @@ const ListProjectCard: React.FC<ListProjectCardProps> = ({ project, onClick }) =
             )}
           </div>
           
-          <button
-            onClick={() => handleProjectClick(project, 'invest')}
-            className="px-6 py-2 bg-gradient-to-r from-purple-600 to-blue-600 text-white rounded-lg font-medium hover:from-purple-500 hover:to-blue-500 transition-all duration-300"
-          >
-            Invest Now
-          </button>
+          <div className="w-full sm:w-auto">
+            <SwipeToInvest
+              amount={25000}
+              onConfirm={() => handleProjectClick(project, 'invest')}
+            />
+          </div>
         </div>
         
         <div className="w-full bg-gray-700 rounded-full h-2">

--- a/src/components/ProjectComparison.tsx
+++ b/src/components/ProjectComparison.tsx
@@ -22,6 +22,7 @@ import { useTheme } from './ThemeProvider';
 import ProjectDetailModal from './ProjectDetailModal';
 import { Project } from '../types';
 import { extendedProjects } from '../data/extendedProjects';
+import SwipeToInvest from './SwipeToInvest';
 
 interface ProjectComparisonProps {
   initialProjects?: Project[];
@@ -789,16 +790,10 @@ const ProjectComparison: React.FC<ProjectComparisonProps> = ({ initialProjects, 
                   {compareProjects.map((project) => (
                     <td key={project.id} className="py-4 px-6">
                       <div className="flex flex-col items-center gap-3">
-                        <button
-                          onClick={() => { setSelectedProject(project); setIsModalOpen(true); }}
-                          className={`w-full py-2 rounded-lg font-medium transition-colors ${
-                            theme === 'light'
-                              ? 'bg-purple-500 hover:bg-purple-600 text-white'
-                              : 'bg-purple-600 hover:bg-purple-700 text-white'
-                          }`}
-                        >
-                          Invest Now
-                        </button>
+                        <SwipeToInvest
+                          amount={25000}
+                          onConfirm={() => { setSelectedProject(project); setIsModalOpen(true); }}
+                        />
                         <button
                           onClick={() => { setSelectedProject(project); setIsModalOpen(true); }}
                           className={`w-full py-2 rounded-lg font-medium transition-colors ${

--- a/src/components/ProjectDetailModal.tsx
+++ b/src/components/ProjectDetailModal.tsx
@@ -28,6 +28,7 @@ import { Project } from '../types';
 import { useTheme } from './ThemeProvider';
 import useIsMobile from '../hooks/useIsMobile';
 import { useToast } from '../hooks/useToast';
+import SwipeToInvest from './SwipeToInvest';
 
 interface ProjectDetailModalProps {
   project: Project | null;
@@ -387,13 +388,9 @@ TITLE CARD: "NEON NIGHTS"`,
                 </div>
 
                 {!isMobile && (
-                  <button
-                    onClick={handleInvest}
-                    disabled={investStatus !== 'idle'}
-                    className="mt-4 w-full sm:w-auto px-6 py-3 rounded-xl bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold hover:from-purple-500 hover:to-blue-500 disabled:opacity-50 transition-all"
-                  >
-                    Invest Now
-                  </button>
+                  <div className="mt-4 w-full sm:w-auto">
+                    <SwipeToInvest amount={investmentAmount} onConfirm={handleInvest} />
+                  </div>
                 )}
               </div>
             </div>
@@ -1101,16 +1098,16 @@ TITLE CARD: "NEON NIGHTS"`,
             animate={{ y: 0 }}
             exit={{ y: 80 }}
             transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-            onClick={() => {
-              try { navigator.vibrate?.(50); } catch {
-                /* ignore */
-              }
-              setShowMobileInvest(true);
-            }}
-            className="fixed bottom-4 left-4 right-4 z-[9998] px-6 py-3 rounded-xl bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold"
+            className="fixed bottom-4 left-4 right-4 z-[9998]"
           >
-            Invest Now
-          </motion.button>
+            <SwipeToInvest
+              amount={investmentAmount}
+              onConfirm={() => {
+                try { navigator.vibrate?.(50); } catch { /* ignore */ }
+                setShowMobileInvest(true);
+              }}
+            />
+          </motion.div>
         )}
 
         {isMobile && showMobileInvest && (

--- a/src/components/SwipeToInvest.tsx
+++ b/src/components/SwipeToInvest.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { motion, useMotionValue, useTransform, AnimatePresence } from 'framer-motion';
+import { Check } from 'lucide-react';
+import confetti from 'canvas-confetti';
+
+interface SwipeToInvestProps {
+  amount: number;
+  onConfirm: () => void;
+}
+
+const SwipeToInvest: React.FC<SwipeToInvestProps> = ({ amount, onConfirm }) => {
+  const x = useMotionValue(0);
+  const progress = useTransform(x, [0, 250], [0, 100]);
+  const [completed, setCompleted] = useState(false);
+
+  const handleDragEnd = (_: any, info: { offset: { x: number } }) => {
+    if (info.offset.x > 200) {
+      setCompleted(true);
+      confetti({ particleCount: 40, spread: 70, origin: { y: 0.6 } });
+      onConfirm();
+      setTimeout(() => {
+        setCompleted(false);
+        x.set(0);
+      }, 1500);
+    } else {
+      x.set(0);
+    }
+  };
+
+  return (
+    <motion.div className="swipe-button select-none">
+      <motion.div className="absolute inset-0 bg-white/20" style={{ width: progress }} />
+      <motion.div
+        drag="x"
+        dragConstraints={{ left: 0, right: 250 }}
+        dragElastic={0}
+        onDragEnd={handleDragEnd}
+        style={{ x }}
+        className="relative z-10 w-full h-full flex items-center justify-center cursor-grab active:cursor-grabbing"
+      >
+        <AnimatePresence mode="wait" initial={false}>
+          {completed ? (
+            <motion.span
+              key="done"
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              exit={{ scale: 0 }}
+              className="flex items-center gap-2"
+            >
+              <Check className="w-5 h-5" /> Invested!
+            </motion.span>
+          ) : (
+            <motion.span key="label" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              ➡️ Swipe to Invest ₹{amount.toLocaleString()}
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </motion.div>
+    </motion.div>
+  );
+};
+
+export default SwipeToInvest;

--- a/src/index.css
+++ b/src/index.css
@@ -1009,3 +1009,30 @@
   0%, 100% { opacity: 0.8; }
   50% { opacity: 0.3; }
 }
+
+.swipe-button {
+  width: 100%;
+  height: 56px;
+  border-radius: 30px;
+  background: linear-gradient(to right, #7e30e1, #4b7aff);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 0 12px rgba(126, 48, 225, 0.6);
+}
+.swipe-button::before {
+  content: '';
+  position: absolute;
+  width: 25%;
+  height: 100%;
+  background: rgba(255,255,255,0.2);
+  animation: swipeGlow 2s linear infinite;
+}
+@keyframes swipeGlow {
+  from { left: -25%; }
+  to { left: 100%; }
+}


### PR DESCRIPTION
## Summary
- create `SwipeToInvest` component with framer-motion
- add supporting CSS for swipe button
- integrate swipe component across project investment buttons
- install canvas-confetti for success animation

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68668665458c832f8cd538647d705e8a